### PR TITLE
fix: fix forward_file lack of POSCAR.ori cause some err

### DIFF
--- a/calypso_bohrium/vasp.py
+++ b/calypso_bohrium/vasp.py
@@ -31,7 +31,7 @@ def vasp_task(pop, task_dir, N_INCAR, command):
    task = Task(
        command=command,
        task_work_path=task_dir,
-       forward_files=["POSCAR", "POTCAR"]
+       forward_files=["POSCAR", "POTCAR", "POSCAR.ori"]
        + [f"INCAR_{idx}" for idx in range(1, N_INCAR + 1)],
        backward_files=["CONTCAR", "OUTCAR", "log", "err"],
    )


### PR DESCRIPTION
In vasp interface, run_command will copy POSCAR.ori to CONTCAR then copy CONTCAR to POSCAR, 
but the POSCAR.ori is not uploaded which cause some log infomation in err file

Here I append POSCAR.ori into forward_files to avoid this issue.